### PR TITLE
Added ClearResponseTypeMaps and RemoveResponseTypeMap methods

### DIFF
--- a/RuiJi.Solr.Net/SolrResponse.cs
+++ b/RuiJi.Solr.Net/SolrResponse.cs
@@ -3,9 +3,6 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace RuiJi.Solr.Net
 {
@@ -24,9 +21,20 @@ namespace RuiJi.Solr.Net
             _responseTypeMap.Add("responseHeader", typeof(SolrResponseHeader));
         }
 
-        public static void AddResponseTypeMap<T>(string property)
+        public static void AddResponseTypeMap<T>(string key)
         {
-            _responseTypeMap.Add(property, typeof(T));
+            _responseTypeMap.Add(key, typeof(T));
+        }
+
+        public static void ClearResponseTypeMaps()
+        {
+            _responseTypeMap.Clear();
+            _responseTypeMap.Add("responseHeader", typeof(SolrResponseHeader));
+        }
+
+        public static bool RemoveResponseTypeMap(string key)
+        {
+            return _responseTypeMap.Remove(key);
         }
 
         public SolrResponse()


### PR DESCRIPTION
* Added ClearResponseTypeMaps and RemoveResponseTypeMap methods for dealing with multiple cores. I was finding that there was no way to change the response type maps when switching from one SOLR core to another in one project,
* Cleaned up class usings,
* Changed argument name from _property_ to _key_ for easier understanding of what you're changing
